### PR TITLE
Harden backend security controls

### DIFF
--- a/backend/app/datasets_api.py
+++ b/backend/app/datasets_api.py
@@ -79,12 +79,13 @@ def create_dataset(payload: DatasetCreate):
     _save_all(items)
     return {"status": "created", "id": ds["id"], "dataset": ds}
 
-@router.get("/debug/paths")
-def debug_paths():
-    return {
-        "APP_DIR": str(APP_DIR),
-        "STORE_DIR": str(STORE_DIR),
-        "DATASETS_JSON": str(DATASETS_JSON),
-        "exists": DATASETS_JSON.exists(),
-        "size": DATASETS_JSON.stat().st_size if DATASETS_JSON.exists() else 0,
-    }
+if os.getenv("ENABLE_DATASET_DEBUG_ENDPOINT") == "1":
+    @router.get("/debug/paths")
+    def debug_paths():
+        return {
+            "APP_DIR": str(APP_DIR),
+            "STORE_DIR": str(STORE_DIR),
+            "DATASETS_JSON": str(DATASETS_JSON),
+            "exists": DATASETS_JSON.exists(),
+            "size": DATASETS_JSON.stat().st_size if DATASETS_JSON.exists() else 0,
+        }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,26 +1,66 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 import pandas as pd
 import numpy as np
 import httpx, os, io, json, uuid, re
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 app = FastAPI(title="Insight Sphere Backend", version="0.1.0")
 
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach a strict set of security-oriented HTTP headers."""
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        headers = {
+            "X-Content-Type-Options": "nosniff",
+            "X-Frame-Options": "DENY",
+            "Referrer-Policy": "same-origin",
+            "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+            "Cross-Origin-Opener-Policy": "same-origin",
+            "Cross-Origin-Embedder-Policy": "require-corp",
+        }
+        for header, value in headers.items():
+            response.headers.setdefault(header, value)
+        return response
+
 # --- CORS ---
 FRONTEND_ORIGIN = os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
+ADDITIONAL_ORIGINS: List[str] = [
+    origin.strip()
+    for origin in os.getenv("ADDITIONAL_CORS_ORIGINS", "").split(",")
+    if origin.strip()
+]
+allow_origins = {FRONTEND_ORIGIN, "http://127.0.0.1:5173", "http://127.0.0.1:5174"}
+allow_origins.update(ADDITIONAL_ORIGINS)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[FRONTEND_ORIGIN, "http://localhost:5174", "http://127.0.0.1:5173", "http://127.0.0.1:5174"],
+    allow_origins=sorted(allow_origins),
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Requested-With"],
 )
+
+allowed_hosts_env = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1")
+allowed_hosts = [host.strip() for host in allowed_hosts_env.split(",") if host.strip()]
+allowed_hosts.append("127.0.0.1")
+allowed_hosts.append("localhost")
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(dict.fromkeys(allowed_hosts)))
+app.add_middleware(SecurityHeadersMiddleware)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 UPLOAD_DIR = os.path.abspath(os.path.join(BASE_DIR, "..", "uploads"))
 os.makedirs(UPLOAD_DIR, exist_ok=True)
+try:
+    MAX_UPLOAD_SIZE_MB = float(os.getenv("MAX_UPLOAD_SIZE_MB", "10"))
+except ValueError:
+    MAX_UPLOAD_SIZE_MB = 10.0
+MAX_UPLOAD_SIZE_MB = max(MAX_UPLOAD_SIZE_MB, 0.1)
+MAX_UPLOAD_SIZE = int(MAX_UPLOAD_SIZE_MB * 1024 * 1024)
 
 def _safe_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9._-]+", "_", name)
@@ -66,6 +106,11 @@ async def api_upload(file: UploadFile = File(...)):
     data = await file.read()
     if not data:
         raise HTTPException(status_code=400, detail="Empty file")
+    if len(data) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Max allowed size is {MAX_UPLOAD_SIZE_MB} MB",
+        )
     # save
     fid = str(uuid.uuid4())
     safe = _safe_name(file.filename or "file")


### PR DESCRIPTION
## Summary
- add security headers and host validation middleware to the FastAPI app
- tighten CORS configuration and enforce configurable upload size limits
- guard the dataset debug endpoint behind an environment flag

## Testing
- python -m compileall backend/app/main.py backend/app/datasets_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c3d55d688327a6aac9a59b878d11