### PR TITLE
Fix import preview and add visualization API support

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -170,4 +170,7 @@ if __name__ == "__main__":
 
 
 from datasets_api import router as datasets_router
+from visualizations_api import router as visualizations_router
+
 app.include_router(datasets_router, prefix="/api/dataset")
+app.include_router(visualizations_router, prefix="/api/visualization")

--- a/backend/app/visualizations_api.py
+++ b/backend/app/visualizations_api.py
@@ -1,0 +1,133 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+from pathlib import Path
+import json
+import uuid
+import time
+import tempfile
+import shutil
+
+router = APIRouter()
+
+APP_DIR = Path(__file__).resolve().parent
+CANDIDATE_DIRS = [APP_DIR.parent / "data", APP_DIR / "data"]
+
+
+def _ensure_store_dir() -> Path:
+    for directory in CANDIDATE_DIRS:
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            return directory
+        except Exception:
+            continue
+    APP_DIR.mkdir(parents=True, exist_ok=True)
+    return APP_DIR
+
+
+STORE_DIR = _ensure_store_dir()
+VISUALIZATIONS_JSON = STORE_DIR / "visualizations.json"
+
+
+def _atomic_write_json(path: Path, data: Any):
+    tmp_path = Path(tempfile.mkstemp(prefix="visualizations_", suffix=".json", dir=str(path.parent))[1])
+    try:
+        with tmp_path.open("w", encoding="utf-8") as tmp_file:
+            json.dump(data, tmp_file, ensure_ascii=False, indent=2)
+        shutil.move(str(tmp_path), str(path))
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def _load_all() -> List[Dict[str, Any]]:
+    for directory in CANDIDATE_DIRS:
+        candidate = directory / "visualizations.json"
+        if candidate.exists():
+            try:
+                with candidate.open("r", encoding="utf-8") as handle:
+                    return json.load(handle)
+            except Exception:
+                return []
+    return []
+
+
+def _save_all(items: List[Dict[str, Any]]):
+    _atomic_write_json(VISUALIZATIONS_JSON, items)
+
+
+class VisualizationConfig(BaseModel):
+    color: Optional[str] = None
+    filterConfig: Dict[str, Any] = Field(default_factory=dict)
+    crossDataset: Optional[bool] = False
+    x_dataset_id: Optional[str] = None
+    y_dataset_id: Optional[str] = None
+    z_dataset_id: Optional[str] = None
+    z_axis: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class VisualizationCreate(BaseModel):
+    title: str = Field(..., description="Название визуализации")
+    type: str = Field("chart", description="Тип визуализации")
+    dataset_id: Optional[str] = None
+    x_axis: Optional[str] = None
+    y_axis: Optional[str] = None
+    description: Optional[str] = ""
+    tags: List[str] = Field(default_factory=list)
+    config: VisualizationConfig = Field(default_factory=VisualizationConfig)
+
+
+class VisualizationUpdate(BaseModel):
+    title: Optional[str] = None
+    type: Optional[str] = None
+    dataset_id: Optional[str] = None
+    x_axis: Optional[str] = None
+    y_axis: Optional[str] = None
+    description: Optional[str] = None
+    tags: Optional[List[str]] = None
+    config: Optional[VisualizationConfig] = None
+
+
+@router.get("/list")
+def list_visualizations():
+    items = _load_all()
+    items.sort(key=lambda item: item.get("created_at", 0), reverse=True)
+    return items
+
+
+@router.post("/create")
+def create_visualization(payload: VisualizationCreate):
+    items = _load_all()
+    data = payload.dict()
+    data["id"] = str(uuid.uuid4())
+    data["created_at"] = int(time.time())
+    items.append(data)
+    _save_all(items)
+    return {"status": "created", "id": data["id"], "visualization": data}
+
+
+@router.put("/{visualization_id}")
+def update_visualization(visualization_id: str, payload: VisualizationUpdate):
+    items = _load_all()
+    for index, item in enumerate(items):
+        if item.get("id") == visualization_id:
+            update_data = payload.dict(exclude_unset=True)
+            if "config" in update_data and isinstance(update_data["config"], VisualizationConfig):
+                update_data["config"] = update_data["config"].dict(exclude_unset=True)
+            items[index] = {**item, **update_data, "id": visualization_id}
+            _save_all(items)
+            return {"status": "updated", "id": visualization_id, "visualization": items[index]}
+    raise HTTPException(status_code=404, detail="Visualization not found")
+
+
+@router.delete("/{visualization_id}")
+def delete_visualization(visualization_id: str):
+    items = _load_all()
+    new_items = [item for item in items if item.get("id") != visualization_id]
+    if len(new_items) == len(items):
+        raise HTTPException(status_code=404, detail="Visualization not found")
+    _save_all(new_items)
+    return {"status": "deleted", "id": visualization_id}

--- a/frontend/src/api/entities.js
+++ b/frontend/src/api/entities.js
@@ -1,9 +1,30 @@
 const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+function sortByOrder(items, orderBy) {
+  if (!Array.isArray(items) || !orderBy) {
+    return Array.isArray(items) ? [...items] : [];
+  }
+  const direction = orderBy.startsWith('-') ? -1 : 1;
+  const field = orderBy.replace(/^[-+]/, '') || orderBy;
+  return [...items].sort((a, b) => {
+    const av = a?.[field];
+    const bv = b?.[field];
+    if (av === bv) return 0;
+    if (av == null) return 1 * direction;
+    if (bv == null) return -1 * direction;
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return av > bv ? direction : -direction;
+    }
+    return String(av).localeCompare(String(bv)) * direction;
+  });
+}
+
 export const Dataset = {
   async list(orderBy = '-created_date') {
     const r = await fetch(`${API_BASE}/api/dataset/list`);
     if (!r.ok) throw new Error(await r.text());
-    return r.json();
+    const data = await r.json();
+    return sortByOrder(data, orderBy);
   },
   async create(payload) {
     const r = await fetch(`${API_BASE}/api/dataset/create`, {
@@ -16,3 +37,63 @@ export const Dataset = {
   },
 };
 export async function getDatasets() { return Dataset.list('-created_date'); }
+
+export const Visualization = {
+  async list(orderBy = '-created_at') {
+    const r = await fetch(`${API_BASE}/api/visualization/list`);
+    if (!r.ok) throw new Error(await r.text());
+    const data = await r.json();
+    return sortByOrder(data, orderBy);
+  },
+  async filter(criteria = {}, orderBy = '-created_at') {
+    const items = await this.list(orderBy);
+    const keys = Object.keys(criteria || {});
+    if (keys.length === 0) return items;
+    return items.filter((item) =>
+      keys.every((key) => {
+        const expected = criteria[key];
+        if (expected == null) return true;
+        const value = item?.[key];
+        if (Array.isArray(expected)) {
+          return expected.includes(value);
+        }
+        if (typeof expected === 'object' && expected !== null) {
+          return Object.entries(expected).every(([subKey, subValue]) => {
+            const nested = value && typeof value === 'object' ? value[subKey] : undefined;
+            return nested === subValue;
+          });
+        }
+        return value === expected;
+      }),
+    );
+  },
+  async create(payload) {
+    const r = await fetch(`${API_BASE}/api/visualization/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  },
+  async update(id, payload) {
+    const r = await fetch(`${API_BASE}/api/visualization/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  },
+  async delete(id) {
+    const r = await fetch(`${API_BASE}/api/visualization/${id}`, {
+      method: 'DELETE',
+    });
+    if (!r.ok) throw new Error(await r.text());
+    return r.json();
+  },
+};
+
+export async function getVisualizations() {
+  return Visualization.list('-created_at');
+}

--- a/frontend/src/components/datasources/DataImportPreview.jsx
+++ b/frontend/src/components/datasources/DataImportPreview.jsx
@@ -1,95 +1,142 @@
-import React, { useState } from 'react';
-import {
+import React, { useEffect, useMemo, useState } from 'react';
 import { Dataset } from '@/api/entities';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Badge } from "@/components/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { FileCheck2, X, AlertTriangle } from 'lucide-react';
 
-export default function DataImportPreview({ datasetInfo, onConfirmImport, onCancel }) {
-  const [name, setName] = useState(datasetInfo.name);
-  
-  const handleImport = async () => {
-    try {
-      setSaving && setSaving(true);
-      const payload = {
-        name: (datasetName || name || 'Набор данных'),
-        description: description || '',
-        tags: Array.isArray(tags) ? tags : [],
-        columns: (selectedColumns || columns || []).map(c => ({ name: c.name || c.column || 'column', type: c.type || 'string', selected: c.selected !== false })),
-        file_url: fileUrl || file_url || null,
-        row_count: extraction?.row_count ?? null,
-        sample_data: Array.isArray(extraction?.sample_data) ? extraction.sample_data.slice(0,50) : null
-      };
-      await Dataset.create(payload);
-      if (typeof loadDatasets === 'function') await loadDatasets();
-      if (typeof onClose === 'function') onClose();
-    } catch (e) {
-      console.error('Import failed', e);
-      alert('Не удалось импортировать набор: ' + (e?.message || e));
-    } finally {
-      setSaving && setSaving(false);
-    }
-  };
-const [description, setDescription] = useState(datasetInfo.description);
-  const [selectedColumns, setSelectedColumns] = useState(datasetInfo.columns || []);
-  const [tags, setTags] = useState(["загружено", "новое"]);
-  const [tagInput, setTagInput] = useState("");
+function normaliseColumns(columns = []) {
+  return columns.map((column, index) => ({
+    name: column?.name || column?.column || `column_${index + 1}`,
+    type: column?.type || 'string',
+    selected: column?.selected !== false,
+  }));
+}
 
-  const handleColumnToggle = (column) => {
-    setSelectedColumns(prev => 
-      prev.some(c => c.name === column.name)
-        ? prev.filter(c => c.name !== column.name)
-        : [...prev, column]
+const DEFAULT_TAGS = ['загружено', 'новое'];
+
+export default function DataImportPreview({ datasetInfo, onConfirmImport, onCancel }) {
+  if (!datasetInfo) {
+    return null;
+  }
+
+  const [name, setName] = useState(datasetInfo?.name || 'Набор данных');
+  const [description, setDescription] = useState(datasetInfo?.description || '');
+  const [tagInput, setTagInput] = useState('');
+  const [tags, setTags] = useState(() => {
+    if (Array.isArray(datasetInfo?.tags) && datasetInfo.tags.length > 0) {
+      return [...datasetInfo.tags];
+    }
+    return [...DEFAULT_TAGS];
+  });
+  const [columnsState, setColumnsState] = useState(() => normaliseColumns(datasetInfo?.columns));
+  const [isSaving, setIsSaving] = useState(false);
+  const sampleData = useMemo(() => datasetInfo?.sample_data || [], [datasetInfo]);
+
+  useEffect(() => {
+    setName(datasetInfo?.name || 'Набор данных');
+    setDescription(datasetInfo?.description || '');
+    setColumnsState(normaliseColumns(datasetInfo?.columns));
+    if (Array.isArray(datasetInfo?.tags) && datasetInfo.tags.length > 0) {
+      setTags([...datasetInfo.tags]);
+    } else {
+      setTags([...DEFAULT_TAGS]);
+    }
+    setTagInput('');
+  }, [datasetInfo]);
+
+  const selectedColumns = useMemo(
+    () => columnsState.filter((column) => column.selected),
+    [columnsState],
+  );
+
+  const hasRealData = useMemo(() => {
+    if (!sampleData || sampleData.length === 0) {
+      return false;
+    }
+    return sampleData.some((row) =>
+      Object.values(row).some((value) => {
+        const str = String(value ?? '').toLowerCase();
+        return !str.includes('пример') && !str.includes('example') && !str.includes('column');
+      }),
+    );
+  }, [sampleData]);
+
+  const handleColumnToggle = (columnName) => {
+    setColumnsState((prev) =>
+      prev.map((column) =>
+        column.name === columnName ? { ...column, selected: !column.selected } : column,
+      ),
     );
   };
-  
-  const handleAddTag = (e) => {
-    if (e.key === 'Enter' && tagInput.trim()) {
-      e.preventDefault();
-      if (!tags.includes(tagInput.trim())) {
-        setTags([...tags, tagInput.trim()]);
-      }
-      setTagInput("");
+
+  const handleAddTag = (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    const value = tagInput.trim();
+    if (!value) return;
+    if (!tags.includes(value)) {
+      setTags([...tags, value]);
     }
+    setTagInput('');
   };
 
   const removeTag = (tagToRemove) => {
-    setTags(tags.filter(tag => tag !== tagToRemove));
+    setTags(tags.filter((tag) => tag !== tagToRemove));
   };
 
-  const handleConfirm = () => {
-    onConfirmImport({
-      name,
-      description,
-      columns: selectedColumns,
-      tags
-    });
-  };
+  const buildPayload = () => ({
+    name: name.trim() || 'Набор данных',
+    description: description.trim(),
+    columns: columnsState,
+    tags,
+  });
 
-  const hasRealData = datasetInfo.sample_data && datasetInfo.sample_data.length > 0 && 
-                     !datasetInfo.sample_data.every(row => 
-                       Object.values(row).some(val => 
-                         String(val).includes('Пример') || 
-                         String(val).includes('Example') ||
-                         String(val).includes('column')
-                       )
-                     );
+  const handleSubmit = async () => {
+    if (isSaving) return;
+    if (selectedColumns.length === 0) {
+      alert('Выберите хотя бы один столбец для импорта.');
+      return;
+    }
+
+    const payload = buildPayload();
+
+    try {
+      setIsSaving(true);
+      if (onConfirmImport) {
+        await onConfirmImport(payload);
+      } else {
+        await Dataset.create({
+          ...payload,
+          file_url: datasetInfo?.file_url || null,
+          row_count: datasetInfo?.row_count ?? null,
+          sample_data: datasetInfo?.sample_data ?? null,
+        });
+      }
+    } catch (error) {
+      console.error('Import failed', error);
+      alert('Не удалось импортировать набор: ' + (error?.message || error));
+      return;
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   return (
-    <Dialog open={true} onOpenChange={onCancel}>
+    <Dialog open onOpenChange={onCancel}>
       <DialogContent className="max-w-6xl h-[85vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-2xl heading-text">
@@ -102,50 +149,65 @@ const [description, setDescription] = useState(datasetInfo.description);
         </DialogHeader>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 py-4 flex-1 overflow-hidden">
-          {/* Left Panel: Configuration */}
           <div className="space-y-4">
             <div>
               <Label htmlFor="name" className="elegant-text">Название набора данных</Label>
-              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+              <Input
+                id="name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
             </div>
             <div>
               <Label htmlFor="description" className="elegant-text">Описание</Label>
-              <Textarea id="description" value={description} onChange={(e) => setDescription(e.target.value)} />
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
             </div>
             <div>
               <Label className="elegant-text">Столбцы для импорта</Label>
               <ScrollArea className="h-48 p-3 border rounded-md bg-slate-50/50">
                 <div className="space-y-2">
-                  {datasetInfo.columns.map(col => (
-                    <div key={col.name} className="flex items-center space-x-2">
+                  {columnsState.map((column) => (
+                    <div key={column.name} className="flex items-center space-x-2">
                       <Checkbox
-                        id={col.name}
-                        checked={selectedColumns.some(c => c.name === col.name)}
-                        onCheckedChange={() => handleColumnToggle(col)}
+                        id={column.name}
+                        checked={column.selected}
+                        onCheckedChange={() => handleColumnToggle(column.name)}
                       />
-                      <Label htmlFor={col.name} className="flex-1 elegant-text text-sm">
-                        {col.name} <span className="text-slate-500">({col.type})</span>
+                      <Label htmlFor={column.name} className="flex-1 elegant-text text-sm">
+                        {column.name}
+                        <span className="text-slate-500"> ({column.type})</span>
                       </Label>
                     </div>
                   ))}
+                  {columnsState.length === 0 && (
+                    <p className="text-sm text-slate-500">Структура столбцов не обнаружена. Добавьте их вручную перед импортом.</p>
+                  )}
                 </div>
               </ScrollArea>
             </div>
             <div>
               <Label htmlFor="tags" className="elegant-text">Теги</Label>
               <div className="flex flex-wrap gap-2 p-2 border rounded-md">
-                {tags.map(tag => (
+                {tags.map((tag) => (
                   <Badge key={tag} variant="secondary" className="elegant-text">
                     {tag}
-                    <button onClick={() => removeTag(tag)} className="ml-1 rounded-full hover:bg-slate-300">
-                      <X className="w-3 h-3"/>
+                    <button
+                      type="button"
+                      onClick={() => removeTag(tag)}
+                      className="ml-1 rounded-full hover:bg-slate-300"
+                    >
+                      <X className="w-3 h-3" />
                     </button>
                   </Badge>
                 ))}
                 <Input
                   id="tags"
                   value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
+                  onChange={(event) => setTagInput(event.target.value)}
                   onKeyDown={handleAddTag}
                   placeholder="Добавить тег..."
                   className="flex-1 border-none shadow-none focus-visible:ring-0 h-6 p-0"
@@ -153,11 +215,10 @@ const [description, setDescription] = useState(datasetInfo.description);
               </div>
             </div>
           </div>
-          
-          {/* Right Panel: Data Sample */}
+
           <div className="space-y-4 flex flex-col">
             <Label className="elegant-text">
-              Образец данных 
+              Образец данных
               {!hasRealData && (
                 <Badge variant="destructive" className="ml-2">
                   <AlertTriangle className="w-3 h-3 mr-1" />
@@ -165,37 +226,38 @@ const [description, setDescription] = useState(datasetInfo.description);
                 </Badge>
               )}
             </Label>
-            
+
             {!hasRealData && (
               <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
                 <p className="text-sm text-yellow-800">
-                  <strong>Внимание:</strong> Не удалось автоматически извлечь данные из файла. 
-                  Показаны примеры на основе структуры. Проверьте корректность столбцов перед импортом.
+                  <strong>Внимание:</strong> Не удалось автоматически извлечь данные из файла. Показаны примеры на основе структуры. Проверьте корректность столбцов перед импортом.
                 </p>
               </div>
             )}
-            
+
             <div className="border rounded-md overflow-hidden flex-1">
               <ScrollArea className="h-full">
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      {selectedColumns.map(col => <TableHead key={col.name}>{col.name}</TableHead>)}
+                      {selectedColumns.map((column) => (
+                        <TableHead key={column.name}>{column.name}</TableHead>
+                      ))}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {(datasetInfo.sample_data?.slice(0, 10) || []).map((row, rowIndex) => (
+                    {(sampleData.slice(0, 10) || []).map((row, rowIndex) => (
                       <TableRow key={rowIndex}>
-                        {selectedColumns.map(col => (
-                          <TableCell key={col.name} className="text-xs">
-                            {String(row[col.name] ?? '')}
+                        {selectedColumns.map((column) => (
+                          <TableCell key={column.name} className="text-xs">
+                            {String(row[column.name] ?? '')}
                           </TableCell>
                         ))}
                       </TableRow>
                     ))}
-                    {(!datasetInfo.sample_data || datasetInfo.sample_data.length === 0) && (
+                    {(sampleData.length === 0 || selectedColumns.length === 0) && (
                       <TableRow>
-                        <TableCell colSpan={selectedColumns.length} className="text-center text-slate-500 py-8">
+                        <TableCell colSpan={Math.max(selectedColumns.length, 1)} className="text-center text-slate-500 py-8">
                           Нет данных для предпросмотра
                         </TableCell>
                       </TableRow>
@@ -208,8 +270,12 @@ const [description, setDescription] = useState(datasetInfo.description);
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onCancel}>Отмена</Button>
-          <Button onClick={handleImport} onClick={handleConfirm} onClick={handleImport}>Импортировать {selectedColumns.length} столбцов</Button>
+          <Button variant="outline" onClick={onCancel} disabled={isSaving}>
+            Отмена
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSaving || columnsState.length === 0}>
+            {isSaving ? 'Импорт...' : `Импортировать ${selectedColumns.length} столбцов`}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- rework the data import preview modal to stabilise column/tag editing and submission flow
- add visualization persistence endpoints on the backend and expose matching frontend API helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5c320f0d083279ec55cbabe823adf