### PR TITLE
Implement full dataset & visualization APIs

### DIFF
--- a/frontend/src/api/entities.js
+++ b/frontend/src/api/entities.js
@@ -1,18 +1,113 @@
 const API_BASE = import.meta.env.VITE_API_BASE || '';
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    let message;
+    try {
+      message = await response.text();
+    } catch (e) {
+      message = response.statusText;
+    }
+    throw new Error(message || 'Request failed');
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function buildQuery(params = {}) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      search.append(key, value);
+    }
+  });
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
 export const Dataset = {
-  async list(orderBy = '-created_date') {
-    const r = await fetch(`${API_BASE}/api/dataset/list`);
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
+  async list(orderBy = '-created_at') {
+    return request(`/api/dataset/list${buildQuery({ order_by: orderBy })}`);
   },
+
+  async get(id) {
+    return request(`/api/dataset/${id}`);
+  },
+
   async create(payload) {
-    const r = await fetch(`${API_BASE}/api/dataset/create`, {
+    return request('/api/dataset/create', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
+  },
+
+  async update(id, payload) {
+    return request(`/api/dataset/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async delete(id) {
+    return request(`/api/dataset/${id}`, {
+      method: 'DELETE',
+    });
   },
 };
-export async function getDatasets() { return Dataset.list('-created_date'); }
+
+export const Visualization = {
+  async list(orderBy = '-created_at') {
+    return request(`/api/visualization/list${buildQuery({ order_by: orderBy })}`);
+  },
+
+  async filter(filters = {}, orderBy = '-created_at') {
+    return request('/api/visualization/filter', {
+      method: 'POST',
+      body: JSON.stringify({ filters, order_by: orderBy }),
+    });
+  },
+
+  async get(id) {
+    return request(`/api/visualization/${id}`);
+  },
+
+  async create(payload) {
+    return request('/api/visualization/create', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async update(id, payload) {
+    return request(`/api/visualization/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async delete(id) {
+    return request(`/api/visualization/${id}`, {
+      method: 'DELETE',
+    });
+  },
+};
+
+export async function getDatasets() {
+  return Dataset.list('-created_at');
+}
+
+export async function getVisualizations() {
+  return Visualization.list('-created_at');
+}

--- a/frontend/src/api/integrations.js
+++ b/frontend/src/api/integrations.js
@@ -30,6 +30,16 @@ async function _InvokeLLM_impl({ prompt, response_json_schema, summary, userQues
   return res.json(); // {response: "..."} или JSON по schema
 }
 
+async function _SendEmail_impl({ to, subject, body, from_name }) {
+  const res = await fetch(`${API_BASE}/api/utils/send-email`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ to, subject, body, from_name }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
 // -------- named exports (все варианты, чтобы не падало нигде) --------
 export async function UploadFile(args) { return _UploadFile_impl(args); }
 export async function uploadFile(args) { return _UploadFile_impl(args); }
@@ -40,6 +50,8 @@ export async function extractDataFromUploadedFile(args) { return _ExtractDataFro
 export async function InvokeLLM(args) { return _InvokeLLM_impl(args); }
 export async function invokeLLM(args) { return _InvokeLLM_impl(args); }
 
+export async function SendEmail(args) { return _SendEmail_impl(args); }
+export async function sendEmail(args) { return _SendEmail_impl(args); }
+
 // заглушки для совместимости со старыми импортами
 export const GenerateImage = async () => { throw new Error('GenerateImage: not implemented locally'); }
-export const SendEmail = async () => { throw new Error('SendEmail: not implemented locally'); }

--- a/frontend/src/components/datasources/DataImportPreview.jsx
+++ b/frontend/src/components/datasources/DataImportPreview.jsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
-import { Dataset } from '@/api/entities';
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,78 +17,85 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { FileCheck2, X, AlertTriangle } from 'lucide-react';
 
+
+function buildInitialTags(datasetInfo) {
+  const baseTags = new Set(["загружено", "новое"]);
+  (datasetInfo?.tags || []).forEach(tag => baseTags.add(tag));
+  return Array.from(baseTags);
+}
+
+
 export default function DataImportPreview({ datasetInfo, onConfirmImport, onCancel }) {
-  const [name, setName] = useState(datasetInfo.name);
-  
-  const handleImport = async () => {
-    try {
-      setSaving && setSaving(true);
-      const payload = {
-        name: (datasetName || name || 'Набор данных'),
-        description: description || '',
-        tags: Array.isArray(tags) ? tags : [],
-        columns: (selectedColumns || columns || []).map(c => ({ name: c.name || c.column || 'column', type: c.type || 'string', selected: c.selected !== false })),
-        file_url: fileUrl || file_url || null,
-        row_count: extraction?.row_count ?? null,
-        sample_data: Array.isArray(extraction?.sample_data) ? extraction.sample_data.slice(0,50) : null
-      };
-      await Dataset.create(payload);
-      if (typeof loadDatasets === 'function') await loadDatasets();
-      if (typeof onClose === 'function') onClose();
-    } catch (e) {
-      console.error('Import failed', e);
-      alert('Не удалось импортировать набор: ' + (e?.message || e));
-    } finally {
-      setSaving && setSaving(false);
-    }
-  };
-const [description, setDescription] = useState(datasetInfo.description);
-  const [selectedColumns, setSelectedColumns] = useState(datasetInfo.columns || []);
-  const [tags, setTags] = useState(["загружено", "новое"]);
-  const [tagInput, setTagInput] = useState("");
+  const safeInfo = datasetInfo || {};
+  const [name, setName] = useState(safeInfo.name || 'Новый набор данных');
+  const [description, setDescription] = useState(safeInfo.description || '');
+  const [selectedColumns, setSelectedColumns] = useState(safeInfo.columns || []);
+  const [tags, setTags] = useState(buildInitialTags(safeInfo));
+  const [tagInput, setTagInput] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleColumnToggle = (column) => {
-    setSelectedColumns(prev => 
-      prev.some(c => c.name === column.name)
-        ? prev.filter(c => c.name !== column.name)
-        : [...prev, column]
-    );
-  };
-  
-  const handleAddTag = (e) => {
-    if (e.key === 'Enter' && tagInput.trim()) {
-      e.preventDefault();
-      if (!tags.includes(tagInput.trim())) {
-        setTags([...tags, tagInput.trim()]);
+  const hasRealData = useMemo(() => {
+    const rows = safeInfo.sample_data;
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return false;
+    }
+    return rows.some(row => Object.values(row || {}).some(value => {
+      const str = String(value ?? '').toLowerCase();
+      return str && !str.includes('пример') && !str.includes('example');
+    }));
+  }, [safeInfo.sample_data]);
+
+  const toggleColumn = (column) => {
+    setSelectedColumns(prev => {
+      const exists = prev.some(c => c.name === column.name);
+      if (exists) {
+        return prev.filter(c => c.name !== column.name);
       }
-      setTagInput("");
-    }
-  };
-
-  const removeTag = (tagToRemove) => {
-    setTags(tags.filter(tag => tag !== tagToRemove));
-  };
-
-  const handleConfirm = () => {
-    onConfirmImport({
-      name,
-      description,
-      columns: selectedColumns,
-      tags
+      return [...prev, column];
     });
   };
 
-  const hasRealData = datasetInfo.sample_data && datasetInfo.sample_data.length > 0 && 
-                     !datasetInfo.sample_data.every(row => 
-                       Object.values(row).some(val => 
-                         String(val).includes('Пример') || 
-                         String(val).includes('Example') ||
-                         String(val).includes('column')
-                       )
-                     );
+  const handleAddTag = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const value = tagInput.trim();
+      if (value && !tags.includes(value)) {
+        setTags([...tags, value]);
+      }
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tag) => {
+    setTags(tags.filter(t => t !== tag));
+  };
+
+  const handleConfirm = async () => {
+    if (!onConfirmImport) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await onConfirmImport({
+        name: name.trim() || 'Новый набор данных',
+        description,
+        columns: selectedColumns,
+        tags,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const sampleRows = useMemo(() => {
+    if (!Array.isArray(safeInfo.sample_data)) {
+      return [];
+    }
+    return safeInfo.sample_data.slice(0, 10);
+  }, [safeInfo.sample_data]);
 
   return (
-    <Dialog open={true} onOpenChange={onCancel}>
+    <Dialog open onOpenChange={onCancel}>
       <DialogContent className="max-w-6xl h-[85vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-2xl heading-text">
@@ -97,55 +103,71 @@ const [description, setDescription] = useState(datasetInfo.description);
             Предварительный просмотр и импорт данных
           </DialogTitle>
           <DialogDescription className="elegant-text">
-            Проверьте данные перед импортом. Вы можете изменить название, описание и выбрать, какие столбцы импортировать.
+            Проверьте структуру набора данных и при необходимости обновите метаданные перед импортом.
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 py-4 flex-1 overflow-hidden">
-          {/* Left Panel: Configuration */}
           <div className="space-y-4">
             <div>
-              <Label htmlFor="name" className="elegant-text">Название набора данных</Label>
-              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+              <Label htmlFor="dataset-name" className="elegant-text">Название набора данных</Label>
+              <Input
+                id="dataset-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Например: Продажи 2024"
+              />
             </div>
+
             <div>
-              <Label htmlFor="description" className="elegant-text">Описание</Label>
-              <Textarea id="description" value={description} onChange={(e) => setDescription(e.target.value)} />
+              <Label htmlFor="dataset-description" className="elegant-text">Описание</Label>
+              <Textarea
+                id="dataset-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Кратко опишите содержимое набора данных"
+              />
             </div>
+
             <div>
               <Label className="elegant-text">Столбцы для импорта</Label>
               <ScrollArea className="h-48 p-3 border rounded-md bg-slate-50/50">
                 <div className="space-y-2">
-                  {datasetInfo.columns.map(col => (
-                    <div key={col.name} className="flex items-center space-x-2">
+                  {(safeInfo.columns || []).map((column) => (
+                    <div key={column.name} className="flex items-center gap-2">
                       <Checkbox
-                        id={col.name}
-                        checked={selectedColumns.some(c => c.name === col.name)}
-                        onCheckedChange={() => handleColumnToggle(col)}
+                        id={`column-${column.name}`}
+                        checked={selectedColumns.some(c => c.name === column.name)}
+                        onCheckedChange={() => toggleColumn(column)}
                       />
-                      <Label htmlFor={col.name} className="flex-1 elegant-text text-sm">
-                        {col.name} <span className="text-slate-500">({col.type})</span>
+                      <Label htmlFor={`column-${column.name}`} className="flex-1 elegant-text text-sm">
+                        {column.name}
+                        <span className="text-slate-500"> ({column.type})</span>
                       </Label>
                     </div>
                   ))}
+                  {(safeInfo.columns || []).length === 0 && (
+                    <p className="text-xs text-slate-500">Структура не определена. Добавьте столбцы вручную после импорта.</p>
+                  )}
                 </div>
               </ScrollArea>
             </div>
+
             <div>
-              <Label htmlFor="tags" className="elegant-text">Теги</Label>
+              <Label htmlFor="dataset-tags" className="elegant-text">Теги</Label>
               <div className="flex flex-wrap gap-2 p-2 border rounded-md">
                 {tags.map(tag => (
                   <Badge key={tag} variant="secondary" className="elegant-text">
                     {tag}
-                    <button onClick={() => removeTag(tag)} className="ml-1 rounded-full hover:bg-slate-300">
-                      <X className="w-3 h-3"/>
+                    <button type="button" onClick={() => handleRemoveTag(tag)} className="ml-1 rounded-full hover:bg-slate-300">
+                      <X className="w-3 h-3" />
                     </button>
                   </Badge>
                 ))}
                 <Input
-                  id="tags"
+                  id="dataset-tags"
                   value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
+                  onChange={(event) => setTagInput(event.target.value)}
                   onKeyDown={handleAddTag}
                   placeholder="Добавить тег..."
                   className="flex-1 border-none shadow-none focus-visible:ring-0 h-6 p-0"
@@ -153,49 +175,50 @@ const [description, setDescription] = useState(datasetInfo.description);
               </div>
             </div>
           </div>
-          
-          {/* Right Panel: Data Sample */}
+
           <div className="space-y-4 flex flex-col">
             <Label className="elegant-text">
-              Образец данных 
+              Образец данных
               {!hasRealData && (
                 <Badge variant="destructive" className="ml-2">
                   <AlertTriangle className="w-3 h-3 mr-1" />
-                  Примеры данных
+                  Примерная структура
                 </Badge>
               )}
             </Label>
-            
+
             {!hasRealData && (
               <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
                 <p className="text-sm text-yellow-800">
-                  <strong>Внимание:</strong> Не удалось автоматически извлечь данные из файла. 
-                  Показаны примеры на основе структуры. Проверьте корректность столбцов перед импортом.
+                  <strong>Внимание:</strong> Не удалось автоматически извлечь реальные строки данных. Проверьте и при необходимости
+                  загрузите значения позднее.
                 </p>
               </div>
             )}
-            
+
             <div className="border rounded-md overflow-hidden flex-1">
               <ScrollArea className="h-full">
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      {selectedColumns.map(col => <TableHead key={col.name}>{col.name}</TableHead>)}
+                      {selectedColumns.map(col => (
+                        <TableHead key={col.name}>{col.name}</TableHead>
+                      ))}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {(datasetInfo.sample_data?.slice(0, 10) || []).map((row, rowIndex) => (
+                    {sampleRows.map((row, rowIndex) => (
                       <TableRow key={rowIndex}>
                         {selectedColumns.map(col => (
                           <TableCell key={col.name} className="text-xs">
-                            {String(row[col.name] ?? '')}
+                            {String(row?.[col.name] ?? '')}
                           </TableCell>
                         ))}
                       </TableRow>
                     ))}
-                    {(!datasetInfo.sample_data || datasetInfo.sample_data.length === 0) && (
+                    {sampleRows.length === 0 && (
                       <TableRow>
-                        <TableCell colSpan={selectedColumns.length} className="text-center text-slate-500 py-8">
+                        <TableCell colSpan={Math.max(selectedColumns.length, 1)} className="text-center text-slate-500 py-8">
                           Нет данных для предпросмотра
                         </TableCell>
                       </TableRow>
@@ -208,8 +231,12 @@ const [description, setDescription] = useState(datasetInfo.description);
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onCancel}>Отмена</Button>
-          <Button onClick={handleImport} onClick={handleConfirm} onClick={handleImport}>Импортировать {selectedColumns.length} столбцов</Button>
+          <Button variant="outline" onClick={onCancel} disabled={isSubmitting}>
+            Отмена
+          </Button>
+          <Button onClick={handleConfirm} disabled={isSubmitting}>
+            Импортировать {selectedColumns.length} {selectedColumns.length === 1 ? 'столбец' : 'столбцов'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/datatransformation/FileConverter.jsx
+++ b/frontend/src/components/datatransformation/FileConverter.jsx
@@ -100,7 +100,7 @@ export default function FileConverter({ supportedFormats, onConversionComplete, 
       let extractedData = null;
       
       try {
-        const extractionResult = await ExtractDataFromUploadedFile({
+        const extractionResult = await extractDataFromUploadedFile({
           file_url,
           json_schema: {
             type: "object",

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -33,17 +33,20 @@ export default function Dashboard() {
   }, []);
 
   const loadData = async () => {
-   setIsLoading(true);
-   try {
-    const datasetsData = await getDatasets();
-    // const visualizationsData = await getVisualizations(); // если реализуешь
-    setDatasets(datasetsData);
-    // setVisualizations(visualizationsData);
-  } catch (error) {
-    console.error('Ошибка загрузки данных:', error);
-  }
-   setIsLoading(false);
-};
+    setIsLoading(true);
+    try {
+      const [datasetsData, visualizationsData] = await Promise.all([
+        getDatasets(),
+        getVisualizations(),
+      ]);
+      setDatasets(Array.isArray(datasetsData) ? datasetsData : []);
+      setVisualizations(Array.isArray(visualizationsData) ? visualizationsData : []);
+    } catch (error) {
+      console.error('Ошибка загрузки данных:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
      
 
   const sampleTrendData = [

--- a/frontend/src/pages/DataSources.jsx
+++ b/frontend/src/pages/DataSources.jsx
@@ -1,5 +1,5 @@
 import { Dataset } from "@/api/entities";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { extractDataFromUploadedFile, uploadFile } from "@/api/integrations";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -38,17 +38,18 @@ export default function DataSources() {
     loadDatasets();
   }, []);
 
-const loadDatasets = async () => {
-  try {
-    const res = await fetch('/api/dataset/list');
-    if (!res.ok) throw new Error(await res.text());
-    const data = await res.json();   // ожидается []
-    setDatasets(data || []);
-  } catch (err) {
-    console.error('Failed to load datasets:', err);
-    setDatasets([]);
-  }
-};
+  const loadDatasets = async () => {
+    setIsLoading(true);
+    try {
+      const data = await Dataset.list('-created_at');
+      setDatasets(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Failed to load datasets:', err);
+      setDatasets([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   const handleFileUpload = async (file) => {
     setIsUploading(true);
@@ -75,7 +76,7 @@ const loadDatasets = async () => {
       if (supportedByExtraction.includes(fileExtension)) {
         // Попробуем извлечь данные с помощью интеграции для поддерживаемых типов
         try {
-          const result = await ExtractDataFromUploadedFile({
+          const result = await extractDataFromUploadedFile({
             file_url: uploadedFileUrl,
             json_schema: {
               type: "object",


### PR DESCRIPTION
## Summary
- add complete CRUD support for datasets and new visualization storage API on the backend
- expose dataset/visualization clients plus email logging endpoint to the frontend integrations layer
- wire every data-oriented page and modal to the real APIs, fixing uploads, imports, dashboard stats, and admin deletion flows

## Testing
- npm run build
- python -m compileall backend/app/main.py backend/app/datasets_api.py backend/app/visualizations_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c41775288327bbb1623c0bf0213a