### PR TITLE
Fix backend API robustness and proxy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ venv/
 .idea/
 .DS_Store
 Thumbs.db
+
+# Runtime data
+backend/data/*.jsonl
+backend/data/visualizations.json
+backend/uploads/

--- a/backend/app/datasets_api.py
+++ b/backend/app/datasets_api.py
@@ -75,8 +75,8 @@ class ColumnInfo(BaseModel):
     selected: Optional[bool] = True
 
 
-class DatasetCreate(BaseModel):
-    name: str = Field(..., description="Название набора")
+class DatasetBase(BaseModel):
+    name: Optional[str] = Field(None, description="Название набора")
     description: Optional[str] = ""
     tags: List[str] = Field(default_factory=list)
     columns: List[ColumnInfo] = Field(default_factory=list)
@@ -85,7 +85,11 @@ class DatasetCreate(BaseModel):
     sample_data: Optional[List[Dict[str, Any]]] = None
 
 
-class DatasetUpdate(DatasetCreate):
+class DatasetCreate(DatasetBase):
+    name: str = Field(..., description="Название набора")
+
+
+class DatasetUpdate(DatasetBase):
     pass
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,6 +59,9 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 os.makedirs(DATA_DIR, exist_ok=True)
 EMAIL_LOG_PATH = os.path.join(DATA_DIR, "email_log.jsonl")
 
+MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", "25"))
+MAX_UPLOAD_SIZE = MAX_UPLOAD_SIZE_MB * 1024 * 1024
+
 def _safe_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9._-]+", "_", name)
 
@@ -177,14 +180,20 @@ async def api_llm(req: LLMReq):
 
     full_prompt = "\n\n".join(prompt_parts)
 
-    async with httpx.AsyncClient(timeout=120) as client:
-        r = await client.post(f"{OLLAMA_URL}/api/generate", json={
-            "model": OLLAMA_MODEL,
-            "prompt": full_prompt,
-            "stream": False
-        })
-        r.raise_for_status()
-        data = r.json()
+    try:
+        async with httpx.AsyncClient(timeout=120) as client:
+            r = await client.post(
+                f"{OLLAMA_URL}/api/generate",
+                json={
+                    "model": OLLAMA_MODEL,
+                    "prompt": full_prompt,
+                    "stream": False,
+                },
+            )
+            r.raise_for_status()
+            data = r.json()
+    except httpx.HTTPError as exc:  # pragma: no cover - network dependent
+        raise HTTPException(status_code=502, detail=f"LLM backend unavailable: {exc}") from exc
 
     text = data.get("response", "")
     if req.response_json_schema:
@@ -228,8 +237,8 @@ if __name__ == "__main__":
 
 
 
-from datasets_api import router as datasets_router
-from visualizations_api import router as visualizations_router
+from .datasets_api import router as datasets_router
+from .visualizations_api import router as visualizations_router
 
 app.include_router(datasets_router, prefix="/api/dataset")
 app.include_router(visualizations_router, prefix="/api/visualization")

--- a/backend/app/visualizations_api.py
+++ b/backend/app/visualizations_api.py
@@ -69,8 +69,8 @@ def _save_all(items: List[Dict[str, Any]]):
 
 
 class VisualizationBase(BaseModel):
-    title: str
-    type: str = "chart"
+    title: Optional[str] = None
+    type: Optional[str] = "chart"
     dataset_id: Optional[str] = None
     config: Dict[str, Any] = Field(default_factory=dict)
     summary: Optional[Dict[str, Any]] = None
@@ -82,7 +82,8 @@ class VisualizationBase(BaseModel):
 
 
 class VisualizationCreate(VisualizationBase):
-    pass
+    title: str
+    type: str = "chart"
 
 
 class VisualizationUpdate(VisualizationBase):

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://localhost:8000',
         changeOrigin: true,
         secure: false
       }


### PR DESCRIPTION
## Summary
- allow partial dataset and visualization updates while preserving create validation
- add upload size configuration, graceful LLM unavailability handling, and fix package imports
- point the Vite dev proxy at the FastAPI port and ignore generated backend artefacts

## Testing
- python - <<'PY' (upload + extract flow) ✅
- python - <<'PY' (dataset CRUD and validation) ✅
- python - <<'PY' (visualization CRUD) ✅
- python - <<'PY' (email logging endpoint) ✅
- python - <<'PY' (LLM fallback behaviour) ✅
- browser_container.run_playwright_script (UI dataset import flow) ✅

------
https://chatgpt.com/codex/tasks/task_e_68e5ca65026083278255a3e5be16f7db