### PR TITLE
Fix navigation URLs to match registered routes

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -2,5 +2,10 @@
 
 
 export function createPageUrl(pageName: string) {
-    return '/' + pageName.toLowerCase().replace(/ /g, '-');
+    // Preserve the original casing of the page name so that the generated URL
+    // matches the defined react-router routes. Converting everything to
+    // lowercase (as was done previously) caused links like `/dashboard` to be
+    // generated, while the application only registers `/Dashboard`, leading to
+    // navigation failures.
+    return "/" + pageName.trim().replace(/\s+/g, "");
 }


### PR DESCRIPTION
## Summary
- update the createPageUrl helper to preserve route casing so sidebar links match existing React Router paths
- trim whitespace while keeping spacing removal without forcing lower-case slugs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5cdce97188327b887916d626cce51