### PR TITLE
Improve network graph accuracy and add correlation utilities

### DIFF
--- a/frontend/src/components/networks/NetworkBuilder.jsx
+++ b/frontend/src/components/networks/NetworkBuilder.jsx
@@ -78,13 +78,16 @@ export default function NetworkBuilder({ datasets, onSave, onCancel }) {
         social: `Проанализируйте данные как социальную сеть. Идентифицируйте ключевых акторов (узлы) и их взаимодействия (связи) на основе столбцов: ${config.selectedColumns.join(', ')}. Рассчитайте центральность узлов.`,
         geo: `Создайте граф пространственных связей. Узлы - это локации, ребра - сила связи между ними (например, корреляция событий). Используйте столбцы: ${config.selectedColumns.join(', ')}.`
     };
-    
-    // In a real application, you'd pass the actual dataset data here to the LLM.
-    // For this example, we'll simulate it by only passing the column names.
-    // Assuming `InvokeLLM` somehow gets access to the current dataset rows.
+
+    const columnMetadata = selectedDataset?.columns || [];
+    const previewRows = selectedDataset?.sample_data?.slice(0, 50) || [];
+
     const prompt = `
-        Вы — эксперт по графовому анализу. На основе предоставленных данных и задачи, сгенерируйте структуру графа.
+        Вы — эксперт по графовому анализу. Используйте фактические данные, приведенные ниже, чтобы построить структуру графа без домыслов.
         Задача: ${prompts[config.graphType]}
+        Метаданные столбцов: ${JSON.stringify(columnMetadata)}
+        Пример строк данных (не более 50): ${JSON.stringify(previewRows)}
+        Если корреляция между столбцами менее 0.3 по модулю, связь не добавляйте.
         Предоставьте результат в формате JSON, соответствующем схеме.
     `;
 
@@ -277,7 +280,11 @@ export default function NetworkBuilder({ datasets, onSave, onCancel }) {
         </CardHeader>
         <CardContent className="p-6">
           {generatedGraph ? (
-            <NetworkVisualization config={config} graphData={generatedGraph} />
+            <NetworkVisualization
+              config={config}
+              graphData={generatedGraph}
+              dataset={selectedDataset}
+            />
           ) : isGenerating ? (
             <div className="h-96 flex items-center justify-center text-slate-500 elegant-text">
                 <div className="text-center">

--- a/frontend/src/components/networks/NetworkVisualization.jsx
+++ b/frontend/src/components/networks/NetworkVisualization.jsx
@@ -1,121 +1,147 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from "react";
 import { Card } from "@/components/ui/card";
+import {
+  attachDegrees,
+  buildCorrelationGraph,
+  calculateNodePositions,
+  normaliseGraphData,
+} from "@/lib/networkUtils";
 
-export default function NetworkVisualization({ config }) {
-  const svgRef = useRef();
+export default function NetworkVisualization({ config, graphData, dataset }) {
+  const svgRef = useRef(null);
+
+  const preparedGraph = useMemo(() => {
+    if (graphData?.nodes?.length && graphData?.links?.length) {
+      return normaliseGraphData(graphData, config);
+    }
+
+    if (dataset?.sample_data?.length) {
+      return buildCorrelationGraph({
+        selectedColumns: config.selectedColumns,
+        nodeSize: config.nodeSize,
+        sampleData: dataset.sample_data,
+      });
+    }
+
+    return { nodes: [], links: [] };
+  }, [config, dataset, graphData]);
 
   useEffect(() => {
-    if (!svgRef.current || !config.selectedColumns.length) return;
-
     const svg = svgRef.current;
+    if (!svg) return;
+
     const width = svg.clientWidth || 400;
     const height = svg.clientHeight || 400;
 
-    // Очистим предыдущий контент
-    svg.innerHTML = '';
-
-    // Создаем узлы для каждого выбранного столбца
-    const nodes = config.selectedColumns.map((column, index) => ({
-      id: column,
-      x: width / 2 + Math.cos((index / config.selectedColumns.length) * 2 * Math.PI) * 100,
-      y: height / 2 + Math.sin((index / config.selectedColumns.length) * 2 * Math.PI) * 100,
-      radius: config.nodeSize === 'small' ? 15 : config.nodeSize === 'medium' ? 25 : 35
-    }));
-
-    // Создаем связи между узлами (имитация корреляций)
-    const links = [];
-    for (let i = 0; i < nodes.length; i++) {
-      for (let j = i + 1; j < nodes.length; j++) {
-        const correlation = Math.random() * 2 - 1; // Случайная корреляция от -1 до 1
-        if (Math.abs(correlation) > 0.3) { // Показываем только значимые связи
-          links.push({
-            source: nodes[i],
-            target: nodes[j],
-            strength: Math.abs(correlation),
-            type: correlation > 0 ? 'positive' : 'negative'
-          });
-        }
-      }
+    while (svg.firstChild) {
+      svg.removeChild(svg.firstChild);
     }
 
-    // Рисуем связи
-    links.forEach(link => {
-      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-      line.setAttribute('x1', link.source.x);
-      line.setAttribute('y1', link.source.y);
-      line.setAttribute('x2', link.target.x);
-      line.setAttribute('y2', link.target.y);
-      line.setAttribute('stroke', link.type === 'positive' ? '#10B981' : '#EF4444');
-      line.setAttribute('stroke-width', link.strength * 3);
-      line.setAttribute('opacity', '0.7');
+    const { nodes, links } = preparedGraph ?? { nodes: [], links: [] };
+    if (!nodes.length) {
+      return;
+    }
+
+    const nodesWithDegree = attachDegrees(nodes, links);
+    const positionedNodes = calculateNodePositions(
+      nodesWithDegree,
+      config.layout,
+      width,
+      height,
+    );
+
+    const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    const gradient = document.createElementNS("http://www.w3.org/2000/svg", "linearGradient");
+    gradient.setAttribute("id", "nodeGradient");
+
+    const stop1 = document.createElementNS("http://www.w3.org/2000/svg", "stop");
+    stop1.setAttribute("offset", "0%");
+    stop1.setAttribute("stop-color", "#06B6D4");
+
+    const stop2 = document.createElementNS("http://www.w3.org/2000/svg", "stop");
+    stop2.setAttribute("offset", "100%");
+    stop2.setAttribute("stop-color", "#3B82F6");
+
+    gradient.appendChild(stop1);
+    gradient.appendChild(stop2);
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
+    links.forEach((link) => {
+      const sourceNode = positionedNodes.find((node) => node.id === link.source);
+      const targetNode = positionedNodes.find((node) => node.id === link.target);
+      if (!sourceNode || !targetNode) return;
+
+      const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", sourceNode.x);
+      line.setAttribute("y1", sourceNode.y);
+      line.setAttribute("x2", targetNode.x);
+      line.setAttribute("y2", targetNode.y);
+      line.setAttribute("stroke", link.type === "negative" ? "#EF4444" : "#10B981");
+      line.setAttribute("stroke-width", String(Math.max(link.strength * 4, 1)));
+      line.setAttribute("opacity", "0.7");
       svg.appendChild(line);
     });
 
-    // Рисуем узлы
-    nodes.forEach(node => {
-      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-      circle.setAttribute('cx', node.x);
-      circle.setAttribute('cy', node.y);
-      circle.setAttribute('r', node.radius);
-      circle.setAttribute('fill', 'url(#nodeGradient)');
-      circle.setAttribute('stroke', '#1E293B');
-      circle.setAttribute('stroke-width', '2');
+    positionedNodes.forEach((node) => {
+      const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      circle.setAttribute("cx", node.x);
+      circle.setAttribute("cy", node.y);
+      circle.setAttribute("r", String(node.radius));
+      circle.setAttribute("fill", "url(#nodeGradient)");
+      circle.setAttribute("stroke", "#1E293B");
+      circle.setAttribute("stroke-width", "2");
       svg.appendChild(circle);
 
       if (config.showLabels) {
-        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        text.setAttribute('x', node.x);
-        text.setAttribute('y', node.y + 5);
-        text.setAttribute('text-anchor', 'middle');
-        text.setAttribute('fill', '#1E293B');
-        text.setAttribute('font-size', '12');
-        text.setAttribute('font-weight', 'bold');
+        const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        text.setAttribute("x", node.x);
+        text.setAttribute("y", node.y + node.radius + 14);
+        text.setAttribute("text-anchor", "middle");
+        text.setAttribute("fill", "#1E293B");
+        text.setAttribute("font-size", "12");
+        text.setAttribute("font-weight", "600");
         text.textContent = node.id;
         svg.appendChild(text);
       }
     });
+  }, [config.layout, config.showLabels, preparedGraph]);
 
-    // Добавляем градиент для узлов
-    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
-    const gradient = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
-    gradient.setAttribute('id', 'nodeGradient');
-    
-    const stop1 = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
-    stop1.setAttribute('offset', '0%');
-    stop1.setAttribute('stop-color', '#06B6D4');
-    
-    const stop2 = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
-    stop2.setAttribute('offset', '100%');
-    stop2.setAttribute('stop-color', '#3B82F6');
-    
-    gradient.appendChild(stop1);
-    gradient.appendChild(stop2);
-    defs.appendChild(gradient);
-    svg.insertBefore(defs, svg.firstChild);
-
-  }, [config]);
+  const hasData = preparedGraph?.nodes?.length;
 
   return (
-    <div className="w-full h-96 bg-gradient-to-br from-slate-50 to-blue-50 rounded-xl border border-slate-200 overflow-hidden">
+    <Card className="relative w-full h-96 bg-gradient-to-br from-slate-50 to-blue-50 border border-slate-200 overflow-hidden">
+      {!hasData && (
+        <div className="absolute inset-0 flex items-center justify-center text-slate-500 elegant-text">
+          <div className="text-center px-6">
+            <p className="font-medium">Недостаточно данных для построения графа</p>
+            <p className="text-sm mt-1">
+              Выберите минимум два числовых столбца или дождитесь результатов генерации графа
+            </p>
+          </div>
+        </div>
+      )}
       <svg
         ref={svgRef}
         width="100%"
         height="100%"
         viewBox="0 0 400 400"
         className="w-full h-full"
+        role="img"
+        aria-label="Network visualization"
       />
-      <div className="absolute bottom-4 left-4 text-xs text-slate-500 elegant-text">
+      <div className="absolute bottom-4 left-4 text-xs text-slate-500 elegant-text bg-white/80 px-3 py-2 rounded-lg shadow-sm">
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <div className="w-3 h-0.5 bg-emerald-500"></div>
+            <div className="w-3 h-0.5 bg-emerald-500" />
             <span>Положительная связь</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-3 h-0.5 bg-red-500"></div>
+            <div className="w-3 h-0.5 bg-red-500" />
             <span>Отрицательная связь</span>
           </div>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/lib/networkUtils.js
+++ b/frontend/src/lib/networkUtils.js
@@ -1,0 +1,231 @@
+const NODE_SIZE_MAP = {
+  small: 15,
+  medium: 25,
+  large: 35,
+};
+
+function toNumber(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+export function computePearsonCorrelation(seriesA, seriesB) {
+  if (seriesA.length !== seriesB.length) {
+    throw new Error("Series must have the same length");
+  }
+
+  const filtered = seriesA
+    .map((value, index) => {
+      const a = toNumber(value);
+      const b = toNumber(seriesB[index]);
+      return a === null || b === null ? null : [a, b];
+    })
+    .filter(Boolean);
+
+  const n = filtered.length;
+  if (n < 2) {
+    return 0;
+  }
+
+  let sumA = 0;
+  let sumB = 0;
+  filtered.forEach(([a, b]) => {
+    sumA += a;
+    sumB += b;
+  });
+
+  const meanA = sumA / n;
+  const meanB = sumB / n;
+
+  let numerator = 0;
+  let denomA = 0;
+  let denomB = 0;
+
+  filtered.forEach(([a, b]) => {
+    const diffA = a - meanA;
+    const diffB = b - meanB;
+    numerator += diffA * diffB;
+    denomA += diffA * diffA;
+    denomB += diffB * diffB;
+  });
+
+  if (denomA === 0 || denomB === 0) {
+    return 0;
+  }
+
+  return numerator / Math.sqrt(denomA * denomB);
+}
+
+export function buildCorrelationGraph({
+  selectedColumns,
+  nodeSize,
+  sampleData = [],
+  correlationThreshold = 0.3,
+}) {
+  if (!Array.isArray(selectedColumns) || selectedColumns.length < 2) {
+    return { nodes: [], links: [] };
+  }
+
+  const columnValues = selectedColumns.reduce((acc, column) => {
+    acc[column] = sampleData.map((row) => row?.[column]);
+    return acc;
+  }, {});
+
+  const nodes = selectedColumns.map((column) => ({
+    id: column,
+    radius: NODE_SIZE_MAP[nodeSize] ?? NODE_SIZE_MAP.medium,
+  }));
+
+  const links = [];
+  for (let i = 0; i < selectedColumns.length; i += 1) {
+    for (let j = i + 1; j < selectedColumns.length; j += 1) {
+      const source = selectedColumns[i];
+      const target = selectedColumns[j];
+      const correlation = computePearsonCorrelation(
+        columnValues[source] ?? [],
+        columnValues[target] ?? [],
+      );
+
+      if (Math.abs(correlation) >= correlationThreshold) {
+        links.push({
+          source,
+          target,
+          strength: Math.abs(correlation),
+          type: correlation >= 0 ? "positive" : "negative",
+        });
+      }
+    }
+  }
+
+  return { nodes, links };
+}
+
+export function normaliseGraphData(graphData, { nodeSize, selectedColumns }) {
+  if (!graphData || !Array.isArray(graphData.nodes) || !Array.isArray(graphData.links)) {
+    return null;
+  }
+
+  const nodeSizeValue = NODE_SIZE_MAP[nodeSize] ?? NODE_SIZE_MAP.medium;
+  const providedNodes = new Map();
+
+  graphData.nodes.forEach((node) => {
+    if (!node?.id) return;
+    providedNodes.set(node.id, {
+      id: node.id,
+      radius: node.radius ?? nodeSizeValue,
+      group: node.group ?? null,
+    });
+  });
+
+  if (Array.isArray(selectedColumns)) {
+    selectedColumns.forEach((column) => {
+      if (!providedNodes.has(column)) {
+        providedNodes.set(column, {
+          id: column,
+          radius: nodeSizeValue,
+          group: null,
+        });
+      }
+    });
+  }
+
+  const nodes = Array.from(providedNodes.values());
+  const links = graphData.links
+    .map((link) => {
+      if (!link) return null;
+      const source = typeof link.source === "object" ? link.source.id : link.source;
+      const target = typeof link.target === "object" ? link.target.id : link.target;
+      if (!source || !target) return null;
+
+      const value = Number(link.value ?? link.strength ?? 0);
+      const strength = Number.isFinite(value) ? Math.max(Math.min(Math.abs(value), 1), 0) : 0;
+
+      return {
+        source,
+        target,
+        strength,
+        type: (link.type ?? (value >= 0 ? "positive" : "negative")) === "negative"
+          ? "negative"
+          : "positive",
+      };
+    })
+    .filter(Boolean);
+
+  return { nodes, links };
+}
+
+export function calculateNodePositions(nodes, layout, width, height) {
+  if (!nodes.length) {
+    return [];
+  }
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.min(width, height) / 2.5;
+
+  if (layout === "grid") {
+    const columns = Math.ceil(Math.sqrt(nodes.length));
+    const rows = Math.ceil(nodes.length / columns);
+    const cellWidth = width / (columns + 1);
+    const cellHeight = height / (rows + 1);
+
+    return nodes.map((node, index) => {
+      const row = Math.floor(index / columns) + 1;
+      const column = (index % columns) + 1;
+      return {
+        ...node,
+        x: cellWidth * column,
+        y: cellHeight * row,
+      };
+    });
+  }
+
+  if (layout === "circle") {
+    return nodes.map((node, index) => {
+      const angle = (index / nodes.length) * 2 * Math.PI;
+      return {
+        ...node,
+        x: centerX + Math.cos(angle) * radius,
+        y: centerY + Math.sin(angle) * radius,
+      };
+    });
+  }
+
+  // simple deterministic "force" layout: heavier nodes closer to center based on degree
+  const maxDegree = nodes.reduce((acc, node) => Math.max(acc, node.degree ?? 0), 0) || 1;
+
+  return nodes.map((node, index) => {
+    const angle = (index / nodes.length) * 2 * Math.PI;
+    const degreeFactor = 1 - (node.degree ?? 0) / (maxDegree + 1);
+    const distance = radius * (0.4 + degreeFactor * 0.6);
+    return {
+      ...node,
+      x: centerX + Math.cos(angle) * distance,
+      y: centerY + Math.sin(angle) * distance,
+    };
+  });
+}
+
+export function attachDegrees(nodes, links) {
+  const degreeMap = new Map();
+
+  links.forEach((link) => {
+    degreeMap.set(link.source, (degreeMap.get(link.source) ?? 0) + 1);
+    degreeMap.set(link.target, (degreeMap.get(link.target) ?? 0) + 1);
+  });
+
+  return nodes.map((node) => ({
+    ...node,
+    degree: degreeMap.get(node.id) ?? 0,
+  }));
+}
+
+export const __TEST_ONLY__ = {
+  NODE_SIZE_MAP,
+  toNumber,
+};
+

--- a/frontend/src/lib/networkUtils.test.js
+++ b/frontend/src/lib/networkUtils.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachDegrees,
+  buildCorrelationGraph,
+  calculateNodePositions,
+  computePearsonCorrelation,
+  normaliseGraphData,
+} from "./networkUtils";
+
+const sampleData = [
+  { sales: 10, profit: 5, loss: -5 },
+  { sales: 20, profit: 10, loss: -10 },
+  { sales: 30, profit: 15, loss: -15 },
+  { sales: 40, profit: 20, loss: -20 },
+];
+
+describe("computePearsonCorrelation", () => {
+  it("returns 1 for identical series", () => {
+    const values = [1, 2, 3, 4];
+    expect(computePearsonCorrelation(values, values)).toBeCloseTo(1, 5);
+  });
+
+  it("returns -1 for perfectly inverse series", () => {
+    const values = [1, 2, 3, 4];
+    const inverted = values.map((value) => -value);
+    expect(computePearsonCorrelation(values, inverted)).toBeCloseTo(-1, 5);
+  });
+
+  it("ignores non-numeric values", () => {
+    const left = [1, "", 3, "n/a", 5];
+    const right = [2, 4, 6, 8, 10];
+    expect(computePearsonCorrelation(left, right)).toBeCloseTo(1, 5);
+  });
+});
+
+describe("buildCorrelationGraph", () => {
+  it("creates links for strongly correlated columns", () => {
+    const graph = buildCorrelationGraph({
+      selectedColumns: ["sales", "profit", "loss"],
+      nodeSize: "medium",
+      sampleData,
+      correlationThreshold: 0.5,
+    });
+
+    const pair = graph.links.find((link) => link.source === "sales" && link.target === "profit");
+    expect(pair?.strength).toBeGreaterThan(0.99);
+    expect(pair?.type).toBe("positive");
+
+    const inversePair = graph.links.find((link) => link.source === "profit" && link.target === "loss");
+    expect(inversePair?.type).toBe("negative");
+    expect(inversePair?.strength).toBeGreaterThan(0.99);
+  });
+
+  it("returns empty graph if columns are insufficient", () => {
+    const graph = buildCorrelationGraph({
+      selectedColumns: ["only"],
+      nodeSize: "small",
+      sampleData,
+    });
+    expect(graph.nodes).toHaveLength(0);
+    expect(graph.links).toHaveLength(0);
+  });
+});
+
+describe("normaliseGraphData", () => {
+  it("normalises nodes and links from generated graph", () => {
+    const graphData = {
+      nodes: [{ id: "A" }],
+      links: [{ source: "A", target: "B", value: 0.8 }],
+    };
+
+    const result = normaliseGraphData(graphData, { nodeSize: "large", selectedColumns: ["A", "B"] });
+
+    expect(result?.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "A", radius: expect.any(Number) }),
+        expect.objectContaining({ id: "B" }),
+      ]),
+    );
+    expect(result?.links[0]).toMatchObject({ source: "A", target: "B", strength: 0.8, type: "positive" });
+  });
+});
+
+describe("attachDegrees", () => {
+  it("assigns degree counts to nodes", () => {
+    const nodes = [{ id: "A" }, { id: "B" }, { id: "C" }];
+    const links = [
+      { source: "A", target: "B" },
+      { source: "A", target: "C" },
+    ];
+
+    const result = attachDegrees(nodes, links);
+    const nodeA = result.find((node) => node.id === "A");
+    expect(nodeA?.degree).toBe(2);
+    expect(result.find((node) => node.id === "B")?.degree).toBe(1);
+  });
+});
+
+describe("calculateNodePositions", () => {
+  const nodes = [
+    { id: "A", radius: 10, degree: 2 },
+    { id: "B", radius: 10, degree: 1 },
+    { id: "C", radius: 10, degree: 0 },
+  ];
+
+  it("supports circle layout", () => {
+    const positioned = calculateNodePositions(nodes, "circle", 400, 400);
+    expect(positioned).toHaveLength(3);
+    positioned.forEach((node) => {
+      expect(node.x).toBeGreaterThan(0);
+      expect(node.y).toBeGreaterThan(0);
+    });
+  });
+
+  it("supports grid layout", () => {
+    const positioned = calculateNodePositions(nodes, "grid", 400, 400);
+    expect(positioned).toHaveLength(3);
+    expect(new Set(positioned.map((node) => node.x)).size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- render network graphs using normalized LLM output or dataset-based correlations instead of random links
- include dataset metadata and sample rows in the LLM prompt when generating network graphs
- add shared utilities for correlation calculations with unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e678a57cb0832798a5747ad148e784