### PR TITLE
Fix CSV ingestion warning

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -75,7 +75,12 @@ def read_table_bytes(file_bytes: bytes, filename: str) -> pd.DataFrame:
         return pd.read_excel(io.BytesIO(file_bytes))
     elif ext in [".csv", ".tsv"]:
         sep = "\t" if ext == ".tsv" else None
-        return pd.read_csv(io.BytesIO(file_bytes), sep=sep)
+        read_kwargs = {"sep": sep}
+        if sep is None:
+            # Let pandas automatically detect delimiters without emitting
+            # a fallback warning by explicitly selecting the python engine.
+            read_kwargs["engine"] = "python"
+        return pd.read_csv(io.BytesIO(file_bytes), **read_kwargs)
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported format: {ext}")
 


### PR DESCRIPTION
## Summary
- ensure CSV uploads force pandas to use the python engine when auto-detecting delimiters so parsing stays stable and silent

## Testing
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e681be7da08327b48f3feb4a9745dc