### PR TITLE
Fix email log writer indentation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -304,7 +304,6 @@ async def api_send_email(payload: EmailRequest) -> EmailResponse:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with log_path.open("a", encoding="utf-8") as log_file:
-        with open(log_path, "a", encoding="utf-8") as log_file:
             log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Failed to log email: {exc}")


### PR DESCRIPTION
## Summary
- fix indentation in the email logging endpoint to use a single context manager
- keep outgoing email records appended safely to the log file

## Testing
- python -m py_compile backend/app/main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939dc8ddfb08327bb7f2ed5ddcb8387)