### PR TITLE
Improve email log writing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -304,8 +304,8 @@ async def api_send_email(payload: EmailRequest) -> EmailResponse:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with log_path.open("a", encoding="utf-8") as log_file:
-        with open(log_path, "a", encoding="utf-8") as log_file:
-            log_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+            json.dump(record, log_file, ensure_ascii=False)
+            log_file.write("\n")
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Failed to log email: {exc}")
     return EmailResponse(status="queued", logged=True)


### PR DESCRIPTION
## Summary
- use `json.dump` when appending email audit records for cleaner writes
- keep newline writing explicit while preserving error handling

## Testing
- python -m py_compile backend/app/main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939dc8ddfb08327bb7f2ed5ddcb8387)